### PR TITLE
Add AbstractSMLMConfig and AbstractSMLMInfo types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SMLMData"
 uuid = "5488f106-40b8-4660-84c5-84a168990d1b"
 authors = ["klidke@unm.edu"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/SMLMData.jl
+++ b/src/SMLMData.jl
@@ -60,6 +60,10 @@ export
     AbstractSMLD,
     SMLD,  # Deprecated alias for AbstractSMLD
 
+    # Ecosystem abstract types (tuple pattern)
+    AbstractSMLMConfig,
+    AbstractSMLMInfo,
+
     # Concrete emitter types
     Emitter2D,
     Emitter3D,
@@ -100,6 +104,23 @@ export
     load_smite_2d,
     load_smite_3d,
     save_smite
+
+# Ecosystem abstract types for the (Config, Info, Data) tuple pattern
+"""
+    AbstractSMLMConfig
+
+Abstract supertype for configuration structs in the JuliaSMLM ecosystem.
+Subtypes hold algorithm parameters (e.g., fit settings, simulation parameters).
+"""
+abstract type AbstractSMLMConfig end
+
+"""
+    AbstractSMLMInfo
+
+Abstract supertype for information/results structs in the JuliaSMLM ecosystem.
+Subtypes hold computed metadata or diagnostic output from algorithms.
+"""
+abstract type AbstractSMLMInfo end
 
 # Include all source files
 include("types/emitters.jl")  # Move from current location


### PR DESCRIPTION
## Summary
- Add `AbstractSMLMConfig` and `AbstractSMLMInfo` abstract supertypes for the (Config, Info, Data) tuple pattern used across JuliaSMLM packages
- Exported from SMLMData so all downstream packages (GaussMLE, Boxer, Drift, FrameConnect, Sim, Render, Analysis) can subtype them
- Version bump to v0.7.0

## Test plan
- [x] Full test suite passes (1084/1084)

🤖 Generated with [Claude Code](https://claude.com/claude-code)